### PR TITLE
Fixes behaviour of Dnn in the last pattern of a song

### DIFF
--- a/legacy_gbdk/gbdk_example/gbt_player_bank1.s
+++ b/legacy_gbdk/gbdk_example/gbt_player_bank1.s
@@ -1357,6 +1357,16 @@ gbt_ch1234_jump_position:
 	ld	(gbt_current_step),a
 	ld	hl,#gbt_current_pattern
 	inc	(hl)
+	call	gbt_get_pattern_ptr ; check to see if jump puts us past end of song
+	ld	hl,gbt_current_step_data_ptr
+	ld	a,(hl+)
+	ld	b,a
+	ld	a,(hl)
+	or	a,b
+	jr	nz,dont_loop$
+	xor	a,a
+	ld	(gbt_current_pattern), a
+dont_loop$:
 	ld	a,#1
 	ld	(gbt_update_pattern_pointers),a
 	xor	a,a ;ret 0

--- a/rgbds_example/gbt_player_bank1.asm
+++ b/rgbds_example/gbt_player_bank1.asm
@@ -1340,6 +1340,16 @@ gbt_ch1234_jump_position:
     ld      [gbt_current_step],a
     ld      hl,gbt_current_pattern
     inc [hl]
+    call    gbt_get_pattern_ptr ; check to see if jump puts us past end of song
+    ld      hl,gbt_current_step_data_ptr
+    ld      a,[hl+]
+    ld      b,a
+    ld      a,[hl]
+    or      a,b
+    jr      nz,.dont_loop
+    xor     a,a
+    ld      [gbt_current_pattern], a
+.dont_loop:
     ld      a,1
     ld      [gbt_update_pattern_pointers],a
     xor     a,a ;ret 0


### PR DESCRIPTION
If there was a Dnn effect in the last pattern of a song, gbt-player played garbage. This patch causes it to loop around to pattern 0 instead - the behavior in OpenMPT. It has the added effect of allowing you to play looping songs with intros.