### PR TITLE
Portamento Up/Down and bug fixes.

### DIFF
--- a/legacy_gbdk/gbdk_example/gbt_player.s
+++ b/legacy_gbdk/gbdk_example/gbt_player.s
@@ -101,7 +101,7 @@ gbt_update_pattern_pointers::
 
 ;-------------------------------------------------------------------------------
 
-gbt_get_pattern_ptr:: ; a = pattern number
+gbt_get_pattern_ptr: ; a = pattern number
 
 	; loads a pointer to pattern a into gbt_current_step_data_ptr
 

--- a/legacy_gbdk/gbdk_example/gbt_player_bank1.s
+++ b/legacy_gbdk/gbdk_example/gbt_player_bank1.s
@@ -375,8 +375,8 @@ gbt_ch1_jump_table$:
 gbt_ch1_pan$:
 	and	a,#0x11
 	ld	(gbt_pan+0),a
-	ld	a,#1
-	ret ; ret 1
+	xor	a,a
+	ret ; ret 0 do not update registers, only NR51 at end.
 
 gbt_ch1_arpeggio$:
 	ld	b,a ; b = params
@@ -708,8 +708,8 @@ gbt_ch2_jump_table$:
 gbt_ch2_pan$:
 	and	a,#0x22
 	ld	(gbt_pan+1),a
-	ld	a,#1
-	ret ; ret 1
+	xor	a,a ; ret 0
+	ret ; Should not update registers, only NR51 at end.
 
 gbt_ch2_arpeggio$:
 	ld	b,a ; b = params
@@ -1068,8 +1068,8 @@ gbt_ch3_jump_table$:
 gbt_ch3_pan$:
 	and	a,#0x44
 	ld	(gbt_pan+2),a
-	ld	a,#1
-	ret ; ret 1
+	xor	a,a ; ret 0
+	ret ; do not update registers, only NR51 at end.
 
 gbt_ch3_arpeggio$:
 	ld	b,a ; b = params
@@ -1307,8 +1307,8 @@ gbt_ch4_jump_table$:
 gbt_ch4_pan$:
 	and	a,#0x88
 	ld	(gbt_pan+3),a
-	ld	a,#1
-	ret ; ret 1
+	xor	a,a ; ret 0
+	ret ; do not update registers, only NR51 at end.
 
 gbt_ch4_cut_note$:
 	ld	(gbt_cut_note_tick+3),a

--- a/legacy_gbdk/gbdk_example/gbt_player_bank1.s
+++ b/legacy_gbdk/gbdk_example/gbt_player_bank1.s
@@ -1341,7 +1341,7 @@ gbt_ch1234_jump_position:
 	; Check to see if jump puts us past end of song
 	ld	a,(hl)
 	call	gbt_get_pattern_ptr
-	ld	hl,gbt_current_step_data_ptr
+	ld	hl,#gbt_current_step_data_ptr
 	ld	a,(hl+)
 	ld	b,a
 	ld	a,(hl)

--- a/rgbds_example/gbt_player_bank1.asm
+++ b/rgbds_example/gbt_player_bank1.asm
@@ -356,8 +356,8 @@ gbt_channel_1_set_effect: ; a = effect, de = pointer to data.
 .gbt_ch1_pan:
     and     a,$11
     ld      [gbt_pan+0],a
-    ld      a,1
-    ret ; ret 1
+    xor     a,a
+    ret ; ret 0 do not update registers, only NR51 at end.
 
 .gbt_ch1_arpeggio:
     ld      b,a ; b = params
@@ -689,8 +689,8 @@ gbt_channel_2_set_effect: ; a = effect, de = pointer to data
 .gbt_ch2_pan:
     and     a,$22
     ld      [gbt_pan+1],a
-    ld      a,1
-    ret ; ret 1
+    xor     a,a
+    ret ; ret 0 do not update registers, only NR51 at end.
 
 .gbt_ch2_arpeggio:
     ld      b,a ; b = params
@@ -1049,8 +1049,8 @@ gbt_channel_3_set_effect: ; a = effect, de = pointer to data
 .gbt_ch3_pan:
     and     a,$44
     ld      [gbt_pan+2],a
-    ld      a,1
-    ret ; ret 1
+    xor     a,a
+    ret ; ret 0 do not update registers, only NR51 at end.
 
 .gbt_ch3_arpeggio:
     ld      b,a ; b = params
@@ -1288,8 +1288,8 @@ gbt_channel_4_set_effect: ; a = effect, de = pointer to data
 .gbt_ch4_pan:
     and     a,$88
     ld      [gbt_pan+3],a
-    ld      a,1
-    ret ; ret 1
+    xor     a,a
+    ret ; ret 0 do not update registers, only NR51 at end.
 
 .gbt_ch4_cut_note:
     ld      [gbt_cut_note_tick+3],a


### PR DESCRIPTION
This includes modifications of GBT player i've been working on over the last few moths. Originally designed for gbdk with gbstudio, I will try to bring them to rgbds as well.

1. Fix the new dnn update on gbdk, weird scope issues caused bad reads and illegal opcodes... on gbdk 2.96

2. Pan effects should not update registers (only NR51 which is always updated anyway) so you can set pan at start without noise.

3. Split update registers into trigger and no trigger paths.
Effects on their own, and tick based effects should not set the start bit unless changing volume.

4. Portamento sweep up and sweep down effects implemented (required the register no trigger).
Should remain compatible with existing compiled data, but a new mod2gbt required for effect to compile.
(Undecided if frequency should be allowed to wrap around for performance, or clamp low frequency.)

5. Mod2gbt exception to compile a no op command if arp 00 is sent, just in case it miss reads... 
(Users of gbstudio have come to exploit the fact that volume does not reset with new notes.)

### To come in other pr's...

7. Effect set volume + envelope data directly.
or, volume envelope that remains when setting volume?

6. Swap noise data for mathematical matches in sequence.
You can access all noise speeds in sequence as hex `00 01 02 03`, then `04 05 06 07`, repeat, `14 15 16 17`, `24 25 26 27` etc...

8. Allow pitch on the noise channel!
Send noise data from mod2gbt, as byte 0 bits 6-0 and byte 1 bit 6, for the whole byte.
Notes are rounded to (C D# F# A# C) '4/12':`1/3`, as they produce very close matches in tracker.