### PR TITLE
Dnn and pan fix only

### DIFF
--- a/legacy_gbdk/gbdk_example/gbt_player.s
+++ b/legacy_gbdk/gbdk_example/gbt_player.s
@@ -101,7 +101,7 @@ gbt_update_pattern_pointers::
 
 ;-------------------------------------------------------------------------------
 
-gbt_get_pattern_ptr:: ; a = pattern number
+gbt_get_pattern_ptr: ; a = pattern number
 
 	; loads a pointer to pattern a into gbt_current_step_data_ptr
 

--- a/legacy_gbdk/gbdk_example/gbt_player_bank1.s
+++ b/legacy_gbdk/gbdk_example/gbt_player_bank1.s
@@ -375,8 +375,8 @@ gbt_ch1_jump_table$:
 gbt_ch1_pan$:
 	and	a,#0x11
 	ld	(gbt_pan+0),a
-	ld	a,#1
-	ret ; ret 1
+	xor	a,a
+	ret ; ret 0 do not update registers, only NR51 at end.
 
 gbt_ch1_arpeggio$:
 	ld	b,a ; b = params
@@ -708,8 +708,8 @@ gbt_ch2_jump_table$:
 gbt_ch2_pan$:
 	and	a,#0x22
 	ld	(gbt_pan+1),a
-	ld	a,#1
-	ret ; ret 1
+	xor	a,a ; ret 0
+	ret ; Should not update registers, only NR51 at end.
 
 gbt_ch2_arpeggio$:
 	ld	b,a ; b = params
@@ -1068,8 +1068,8 @@ gbt_ch3_jump_table$:
 gbt_ch3_pan$:
 	and	a,#0x44
 	ld	(gbt_pan+2),a
-	ld	a,#1
-	ret ; ret 1
+	xor	a,a ; ret 0
+	ret ; do not update registers, only NR51 at end.
 
 gbt_ch3_arpeggio$:
 	ld	b,a ; b = params
@@ -1307,8 +1307,8 @@ gbt_ch4_jump_table$:
 gbt_ch4_pan$:
 	and	a,#0x88
 	ld	(gbt_pan+3),a
-	ld	a,#1
-	ret ; ret 1
+	xor	a,a ; ret 0
+	ret ; do not update registers, only NR51 at end.
 
 gbt_ch4_cut_note$:
 	ld	(gbt_cut_note_tick+3),a

--- a/legacy_gbdk/gbdk_example/gbt_player_bank1.s
+++ b/legacy_gbdk/gbdk_example/gbt_player_bank1.s
@@ -1341,7 +1341,7 @@ gbt_ch1234_jump_position:
 	; Check to see if jump puts us past end of song
 	ld	a,(hl)
 	call	gbt_get_pattern_ptr
-	ld	hl,gbt_current_step_data_ptr
+	ld	hl,#gbt_current_step_data_ptr
 	ld	a,(hl+)
 	ld	b,a
 	ld	a,(hl)

--- a/rgbds_example/gbt_player_bank1.asm
+++ b/rgbds_example/gbt_player_bank1.asm
@@ -356,8 +356,8 @@ gbt_channel_1_set_effect: ; a = effect, de = pointer to data.
 .gbt_ch1_pan:
     and     a,$11
     ld      [gbt_pan+0],a
-    ld      a,1
-    ret ; ret 1
+    xor     a,a
+    ret ; ret 0 do not update registers, only NR51 at end.
 
 .gbt_ch1_arpeggio:
     ld      b,a ; b = params
@@ -689,8 +689,8 @@ gbt_channel_2_set_effect: ; a = effect, de = pointer to data
 .gbt_ch2_pan:
     and     a,$22
     ld      [gbt_pan+1],a
-    ld      a,1
-    ret ; ret 1
+    xor     a,a
+    ret ; ret 0 do not update registers, only NR51 at end.
 
 .gbt_ch2_arpeggio:
     ld      b,a ; b = params
@@ -1049,8 +1049,8 @@ gbt_channel_3_set_effect: ; a = effect, de = pointer to data
 .gbt_ch3_pan:
     and     a,$44
     ld      [gbt_pan+2],a
-    ld      a,1
-    ret ; ret 1
+    xor     a,a
+    ret ; ret 0 do not update registers, only NR51 at end.
 
 .gbt_ch3_arpeggio:
     ld      b,a ; b = params
@@ -1288,8 +1288,8 @@ gbt_channel_4_set_effect: ; a = effect, de = pointer to data
 .gbt_ch4_pan:
     and     a,$88
     ld      [gbt_pan+3],a
-    ld      a,1
-    ret ; ret 1
+    xor     a,a
+    ret ; ret 0 do not update registers, only NR51 at end.
 
 .gbt_ch4_cut_note:
     ld      [gbt_cut_note_tick+3],a


### PR DESCRIPTION
**Dnn fix for GBDK.**
**_"Pan fix"_**
Split from #7 to merge quicker.

Note this will not yet tackle the issue of ch1 and 2 not checking if any effects returned 0 or 1 when used on their own, as instr+effect does not check...
Previously I had tackled it with a simple `ret z` after `ch1_instr_effects$:` which will work.


But... after reading through the format guide this is also used to set the instrument, and, it seems if it were working, would always try to set the instrument to 00 if effect was used without instrument?

I don't know if any users in gbstudio take advantage of this, but more often it's been considered a bug, there's seemingly no format guide to **not** set the instrument while setting effects...

**Step 3**
Switching to 2 register paths, note trigger is set with a new note (and volume only), then no trig for everything else, will at least stop buzzing noises for panning before the first note, but i guess effects on their own would still change the ch1-2 instrument somewhat unexpectedly.

Either way, this pan change at least won't break anything, just might not fix it right...