### PR TITLE
Add unbanked support for mod2gbt (GBDK Legacy)

### DIFF
--- a/legacy_gbdk/mod2gbt/mod2gbt.c
+++ b/legacy_gbdk/mod2gbt/mod2gbt.c
@@ -11,6 +11,7 @@
 #include <string.h>
 
 #define DEFAULT_ROM_BANK (2)
+#define BANK_NUM_UNBANKED 0
 
 unsigned int current_output_bank;
 
@@ -863,7 +864,7 @@ void convert_pattern(_pattern_t *pattern, u8 number)
 void print_usage(void)
 {
     printf("Usage: mod2gbt modfile.mod label_name [N]\n");
-    printf("       N: Set output to ROM bank N (defaults to %d).",
+    printf("       N: Set output to ROM bank N (defaults to %d, use 0 for unbanked)",
            DEFAULT_ROM_BANK);
     printf("\n\n");
 }
@@ -898,7 +899,11 @@ int main(int argc, char *argv[])
         }
         else
         {
-            printf("Output to bank: %d\n", current_output_bank);
+            if (current_output_bank == BANK_NUM_UNBANKED) {
+                printf("Bank set to 0, so output will be unbanked\n");
+            } else {
+                printf("Output to bank: %d\n", current_output_bank);
+            }
         }
     }
 
@@ -940,9 +945,11 @@ int main(int argc, char *argv[])
 
     out_write_str("\n// File created by mod2gbt\n\n");
 
-    out_write_str("#pragma bank=");
-    out_write_dec(current_output_bank);
-    out_write_str("\n\n");
+    if (current_output_bank != BANK_NUM_UNBANKED) {
+        out_write_str("#pragma bank=");
+        out_write_dec(current_output_bank);
+        out_write_str("\n\n");
+    }
 
     printf("\nConverting patterns...\n");
     for (i = 0; i < num_patterns; i++)

--- a/legacy_gbdk/mod2gbt/mod2gbt.c
+++ b/legacy_gbdk/mod2gbt/mod2gbt.c
@@ -960,7 +960,7 @@ int main(int argc, char *argv[])
 
     printf("\n\nPattern order...\n");
 
-    out_write_str("const unsigned char * const");
+    out_write_str("const unsigned char * const ");
     out_write_str(label_name);
     out_write_str("_Data[] = {\n");
 


### PR DESCRIPTION
Hi,

Here's a PR if you'd like it. It could be useful for other GBDK folks.

The Issue: 
---
In GBDK (2.9x) I encountered the problem where a non-MBC ROM needs to not have "#pragma bank=" in the mod2gbt output. I didn't see an option to suppress it so I've added it here.  

When the toolchain is set for non-MBC mode it treats "_CODE" as 32K instead of two 16K regions (_CODE and CODE_1) . If you try to use any bank specifier (such as bank=1) then you get the error:
`"ERROR: address overflow (addr c51b >= 8000)"`

This has also been discussed in more detail here:
https://gbdev.gg8.se/forums/viewtopic.php?id=466

The patch:
---
- Add support for unbanked mode. When bank is set to zero ("0") it will suppress the "#pragma bank=" output. There is no loss of functionality (as far as I know) since "#pragma bank=0" is not supported anyway- you specify that by the absence of the bank #pragma.

- Fix a missing space after a "const " specifier
