### PR TITLE
Legacy_gbdk: Fix inverted pause behavior, Unmute volume when resuming playback

### DIFF
--- a/legacy_gbdk/gbdk_example/gbt_player.h
+++ b/legacy_gbdk/gbdk_example/gbt_player.h
@@ -16,6 +16,7 @@
 void gbt_play(void *data, UINT8 bank, UINT8 speed);
 
 // Pauses or unpauses music.
+// Parameter: 1 = un-pause/resume, 0 = pause
 void gbt_pause(UINT8 pause);
 
 // Stops music and turns off sound system. Called automatically when the last

--- a/legacy_gbdk/gbdk_example/gbt_player.s
+++ b/legacy_gbdk/gbdk_example/gbt_player.s
@@ -266,7 +266,7 @@ _gbt_play::
 ;-------------------------------------------------------------------------------
 
 _gbt_pause::
-	lda	hl,2(sp) ; (Parameter: 1 = un-pause/resume, 0 = pause)
+	lda	hl,2(sp)
 	ld	a,(hl)
 	ld	(gbt_playing),a
 	or	a

--- a/legacy_gbdk/gbdk_example/gbt_player.s
+++ b/legacy_gbdk/gbdk_example/gbt_player.s
@@ -266,13 +266,17 @@ _gbt_play::
 ;-------------------------------------------------------------------------------
 
 _gbt_pause::
-	lda	hl,2(sp)
+	lda	hl,2(sp) ; (Parameter: 1 = un-pause/resume, 0 = pause)
 	ld	a,(hl)
 	ld	(gbt_playing),a
 	or	a
-	ret	z
-	xor	a
-	ldh	(#.NR50),a
+	jr	nz,.gbt_pause_unmute
+	ldh	(#.NR50),a ; Mute sound: set L & R sound levels to Off
+	ret
+
+.gbt_pause_unmute: ; Unmute sound if playback is resumed
+	ld	a,#0x77
+	ldh	(#.NR50),a ; Restore L & R sound levels to 100%
 	ret
 
 ;-------------------------------------------------------------------------------

--- a/rgbds_example/gbt_player.asm
+++ b/rgbds_example/gbt_player.asm
@@ -247,9 +247,13 @@ ENDC
 gbt_pause:: ; a = pause/unpause
     ld      [gbt_playing],a
     or      a,a
-    ret     z
-    xor     a,a
-    ld      [rNR50],a
+    jr      nz,.gbt_pause_unmute
+    ld      [rNR50],a ; Mute sound: set L & R sound levels to Off
+    ret
+
+.gbt_pause_unmute: ; Unmute sound if playback is resumed
+    ld      a,$77
+    ld      [rNR50],a ; Restore L & R sound levels to 100%
     ret
 
 ;-------------------------------------------------------------------------------

--- a/rgbds_example/gbt_player.inc
+++ b/rgbds_example/gbt_player.inc
@@ -20,7 +20,7 @@ GBT_PLAYER_INC SET 1
                      ; THIS WILL CHANGE ROM BANK!!!
 
     GLOBAL  gbt_pause ; Pauses or unpauses the song.
-                      ; a = 0 to unpause, anything else to pause.
+                      ; a = 0 to pause, anything else to unpause.
 
     GLOBAL  gbt_loop ; Enables/disables looping at the end of the song.
                      ; a = 0 to stop at the end, anything else to loop


### PR DESCRIPTION
Hi Again :)

I might be misunderstanding the use, but seems like gbt_pause() does not work entirely as expected. 

EDIT: I see that I'm calling gbt_pause() with the opposite of the expected value. I think I was doing that because when called with (1) to pause and (0) to un-pause, it never resumes playback. 

So I think there might be two different issues here: 

- The pause behavior is the opposite of expected. gbt_pause(1) sets gbt_playing = 1 instead of = 0.
- The volume never gets un-muted when playback is resumed with gbt_pause(0)

Here's a proposed patch to mute on pause and unmute on unpause. I don't use ASM much so this may not be optimally written  Hopefully no bugs (was not sure if AF needs to be push/popped?).
