### PR TITLE
Fix Dnn check from bank1.s to player.s, returns to bank 1 (LegacyGBT)

### DIFF
--- a/legacy_gbdk/gbdk_example/gbt_player.s
+++ b/legacy_gbdk/gbdk_example/gbt_player.s
@@ -101,7 +101,7 @@ gbt_update_pattern_pointers::
 
 ;-------------------------------------------------------------------------------
 
-gbt_get_pattern_ptr: ; a = pattern number
+gbt_get_pattern_ptr:: ; a = pattern number
 
 	; loads a pointer to pattern a into gbt_current_step_data_ptr
 
@@ -134,6 +134,25 @@ gbt_get_pattern_ptr: ; a = pattern number
 	ld	(gbt_current_step_data_ptr),a
 	ld	a,h
 	ld	(gbt_current_step_data_ptr+1),a
+
+	ret
+
+;-------------------------------------------------------------------------------
+
+gbt_get_pattern_ptr_banked:: ; a = pattern number
+
+	call gbt_get_pattern_ptr
+	ld	hl,#gbt_current_step_data_ptr
+	ld	a,(hl+)
+	ld	b,a
+	ld	a,(hl)
+	or	a,b
+	jr	nz,dont_loop$
+	xor	a,a
+	ld	(gbt_current_pattern), a
+dont_loop$:
+	ld	a,#0x01
+	ld	(#0x2000),a ; MBC1, MBC3, MBC5 - Set bank
 
 	ret
 

--- a/legacy_gbdk/gbdk_example/gbt_player_bank1.s
+++ b/legacy_gbdk/gbdk_example/gbt_player_bank1.s
@@ -1340,17 +1340,7 @@ gbt_ch1234_jump_position:
 
 	; Check to see if jump puts us past end of song
 	ld	a,(hl)
-	call	gbt_get_pattern_ptr
-	ld	hl,#gbt_current_step_data_ptr
-	ld	a,(hl+)
-	ld	b,a
-	ld	a,(hl)
-	or	a,b
-	jr	nz,dont_loop$
-	xor	a,a
-	ld	(gbt_current_pattern), a
-dont_loop$:
-
+	call	gbt_get_pattern_ptr_banked
 	ld	a,#1
 	ld	(gbt_update_pattern_pointers),a
 	xor	a,a ;ret 0

--- a/rgbds_example/gbt_player.asm
+++ b/rgbds_example/gbt_player.asm
@@ -129,6 +129,30 @@ ENDC
 
 ;-------------------------------------------------------------------------------
 
+gbt_get_pattern_ptr_banked:: ; a = pattern number
+
+	call    gbt_get_pattern_ptr
+    ld      hl,gbt_current_step_data_ptr
+    ld      a,[hl+]
+    ld      b,a
+    ld      a,[hl]
+    or      a,b
+    jr      nz,.dont_loop
+    xor     a,a
+    ld      [gbt_current_pattern], a
+.dont_loop:
+
+IF DEF(GBT_USE_MBC5_512BANKS)
+    xor     a,a
+    ld      [$3000],a
+ENDC
+    ld      a,$01
+    ld      [$2000],a ; MBC1, MBC3, MBC5 - Set bank 1
+
+	ret
+
+;-------------------------------------------------------------------------------
+
 gbt_play:: ; de = data, bc = bank, a = speed
 
     ld      hl,gbt_pattern_array_ptr

--- a/rgbds_example/gbt_player_bank1.asm
+++ b/rgbds_example/gbt_player_bank1.asm
@@ -1323,17 +1323,7 @@ gbt_ch1234_jump_position:
 
     ; Check to see if jump puts us past end of song
     ld      a,[hl]
-    call    gbt_get_pattern_ptr
-    ld      hl,gbt_current_step_data_ptr
-    ld      a,[hl+]
-    ld      b,a
-    ld      a,[hl]
-    or      a,b
-    jr      nz,.dont_loop
-    xor     a,a
-    ld      [gbt_current_pattern], a
-.dont_loop:
-
+    call    gbt_get_pattern_ptr_banked
     ld      a,1
     ld      [gbt_update_pattern_pointers],a
     xor     a,a ;ret 0


### PR DESCRIPTION
Issue from pull #5 and tweak from pull #8 
Songs not in bank 1 would crash on this check as it would remain in the song bank

also reverts :: change as gbdk 2020 was confused, still don't fully understand the : vs :: identifiers.

If i use : now for a called function in another file, under gbdk2020 it spits
`?ASlink-Warning-Undefined Global gbt_get_pattern_ptr_banked referenced by module`
So the new function `gbt_get_pattern_ptr_banked::` has :: 
Technically the old one could remain as : since not called outside the file, but i've reverted it anyway.

This only fixes GBDK Legacy, the issue is likely present in RGBDS if a songs is in bank 2+