### PR TITLE
Use old sdcc calling convention when new GBDK-2020 present

### DIFF
--- a/gb/legacy_gbdk/gbdk_example/gbt_player.h
+++ b/gb/legacy_gbdk/gbdk_example/gbt_player.h
@@ -11,30 +11,38 @@
 
 #include <gb/gb.h>
 
+#ifndef OLDCALL
+  #if __SDCC_REVISION >= 12608
+    #define OLDCALL __sdcccall(0)
+  #else
+    #define OLDCALL
+  #endif
+#endif
+
 // Plays the song pointed by data (pointer array to patterns) in given bank at
 // given initial speed.
-void gbt_play(void *data, UINT8 bank, UINT8 speed);
+void gbt_play(void *data, UINT8 bank, UINT8 speed) OLDCALL;
 
 // Pauses or unpauses music.
 // Parameter: 1 = un-pause/resume, 0 = pause
-void gbt_pause(UINT8 pause);
+void gbt_pause(UINT8 pause) OLDCALL;
 
 // Stops music and turns off sound system. Called automatically when the last
 // pattern ends and autoloop isn't activated.
-void gbt_stop(void);
+void gbt_stop(void) OLDCALL;
 
 // Enables or disables autoloop
-void gbt_loop(UINT8 loop);
+void gbt_loop(UINT8 loop) OLDCALL;
 
 // Updates player, should be called every frame.
 // NOTE: This will change the active ROM bank to 1.
-void gbt_update(void);
+void gbt_update(void) OLDCALL;
 
 // Set enabled channels to prevent the player from using that channel.
 // NOTE: If a channel is re-enabled, it can take some time to sound OK (until
 // pan and volume are modified in the song). You should only disable unused
 // channels or channels that don't change pan or volume.
-void gbt_enable_channels(UINT8 channel_flags);
+void gbt_enable_channels(UINT8 channel_flags) OLDCALL;
 
 #define GBT_CHAN_1 (1<<0)
 #define GBT_CHAN_2 (1<<1)


### PR DESCRIPTION
We've had a few users trying to use gbt-player with newer GBDK-2020 releases. In these releases SDCC uses the new calling convention __sdcccall(1) by default. This causes problems with some gbt-player calls which expect the old calling convention.

This PR changes the header to specify that the old calling convention __sdcccall(0) should be used when built with newer SDCC versions. If an older SDCC is used then the calling convention request will be ignored, allowing it to be compatible in both scenarios.